### PR TITLE
Fix connect task to configuration

### DIFF
--- a/urbansounds8k/get_data.py
+++ b/urbansounds8k/get_data.py
@@ -9,7 +9,7 @@ configuration = {
     'selected_classes': ['air_conditioner', 'car_horn', 'children_playing', 'dog_bark', 'drilling',
                          'engine_idling', 'gun_shot', 'jackhammer', 'siren', 'street_music']
 }
-task.connect(task)
+task.connect(configuration)
 
 
 def get_urbansound8k():


### PR DESCRIPTION
It doesn't make sense to connect the task to itself. I am assuming `task.connect()` was supposed to connect to the configuration and not the task.